### PR TITLE
Fix fatal error when the HTTP variable doesn't exist

### DIFF
--- a/variables/CountryDetectVariable.php
+++ b/variables/CountryDetectVariable.php
@@ -17,7 +17,12 @@ class CountryDetectVariable
 {
     public function country()
     {
-	    $country = $_SERVER["HTTP_CF_IPCOUNTRY"];
-        return $country;
+			if(array_key_exists("HTTP_CF_IPCOUNTRY", $_SERVER)){
+				$country = $_SERVER["HTTP_CF_IPCOUNTRY"];
+					return $country;
+			}
+			else {
+				return "";
+			}
     }
 }


### PR DESCRIPTION
Hey! Small world :)

I found this super useful, but it kept exploding whenever I used it on a local server because Craft didn't like it much when the CF header doesn't exist. I added like two lines that check if the array key exists before trying to access it, and if it doesn't exist it just returns nothing.

Hope that helps, and thanks for making this! 👋 